### PR TITLE
[PRM-446] Changed where we are installing the package for certifi as is required in zip

### DIFF
--- a/.github/workflows/base-gp-registrations-mi.yml
+++ b/.github/workflows/base-gp-registrations-mi.yml
@@ -85,7 +85,7 @@ jobs:
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && inputs.is_deployment
         run: |
           python3 -m venv ./venv
-          ./venv/bin/pip3 install --upgrade pip urllib3 certifi
+          ./venv/bin/pip3 install --upgrade pip urllib3
 
       - name: Build Lambdas
         run: | 

--- a/lambda/shared_requirements.txt
+++ b/lambda/shared_requirements.txt
@@ -1,2 +1,3 @@
 boto3==1.40.0
 botocore==1.40.0
+certifi==2025.8.3


### PR DESCRIPTION
Changed where we are installing the package for certifi as is required in the lambda zip that is deployed